### PR TITLE
Added support for resolvconf enabled systems

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,9 +2,9 @@ package 'dnsmasq'
 
 # If resolvconf package is present we need to configure DNS,
 # otherwise resolving will fail.
-invalid_resolv = !node[:dnsmasq][:enable_dns] || Array(node[:dnsmasq][:dns][:server]).any? {|ip| ip == '127.0.0.1'}
+valid_resolv_config = node[:dnsmasq][:enable_dns] && !Array(node[:dnsmasq][:dns][:server]).any? {|ip| ip == '127.0.0.1'}
 
-if !%x(which resolvconf).empty? && invalid_resolv
+unless %x(which resolvconf).empty? || valid_resolv_config
   Chef::Log.error('Resolving will fail since your configuration is inconsistent')
   raise RuntimeError, "Provide external dns servers and enable dns in dnsmasq"
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,13 +1,13 @@
 package 'dnsmasq'
 
-service 'dnsmasq' do
-  action [:enable, :start]
-end
-
 if(node[:dnsmasq][:enable_dns])
   include_recipe 'dnsmasq::dns'
 end
 
 if(node[:dnsmasq][:enable_dhcp])
   include_recipe 'dnsmasq::dhcp'
+end
+
+service 'dnsmasq' do
+  action [:enable, :start]
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,10 +1,19 @@
 package 'dnsmasq'
 
-if(node[:dnsmasq][:enable_dns])
+# If resolvconf package is present we need to configure DNS,
+# otherwise resolving will fail.
+invalid_resolv = !node[:dnsmasq][:enable_dns] || Array(node[:dnsmasq][:dns][:server]).any? {|ip| ip == '127.0.0.1'}
+
+if !%x(which resolvconf).empty? && invalid_resolv
+  Chef::Log.error('Resolving will fail since your configuration is inconsistent')
+  raise RuntimeError, "Provide external dns servers and enable dns in dnsmasq"
+end
+
+if node[:dnsmasq][:enable_dns]
   include_recipe 'dnsmasq::dns'
 end
 
-if(node[:dnsmasq][:enable_dhcp])
+if node[:dnsmasq][:enable_dhcp]
   include_recipe 'dnsmasq::dhcp'
 end
 

--- a/recipes/dns.rb
+++ b/recipes/dns.rb
@@ -1,9 +1,3 @@
-# We stop dnsmasq because resolv configuration is not yet consistent
-service 'dnsmasq' do
-  only_if "which resolvconf && [ ! -f /etc/dnsmasq.d/dns.conf ]"
-  action :stop
-end
-
 include_recipe 'dnsmasq::default'
 include_recipe 'dnsmasq::manage_hostsfile'
 

--- a/recipes/dns.rb
+++ b/recipes/dns.rb
@@ -1,8 +1,7 @@
 # We stop dnsmasq because resolv configuration is not yet consistent
-unless %x(which resolvconf).empty? || ::File.exist?('/etc/dnsmasq.d/dns.conf')
-  service 'dnsmasq' do
-    action :stop
-  end
+service 'dnsmasq' do
+  only_if "which resolvconf && [ ! -f /etc/dnsmasq.d/dns.conf ]"
+  action :stop
 end
 
 include_recipe 'dnsmasq::default'

--- a/recipes/dns.rb
+++ b/recipes/dns.rb
@@ -1,3 +1,10 @@
+# We stop dnsmasq because resolv configuration is not yet consistent
+unless %x(which resolvconf).empty? || ::File.exist?('/etc/dnsmasq.d/dns.conf')
+  service 'dnsmasq' do
+    action :stop
+  end
+end
+
 include_recipe 'dnsmasq::default'
 include_recipe 'dnsmasq::manage_hostsfile'
 

--- a/recipes/dns.rb
+++ b/recipes/dns.rb
@@ -13,5 +13,5 @@ template '/etc/dnsmasq.d/dns.conf' do
     :config => dns_config,
     :list => node['dnsmasq']['dns_options']
   )
-  notifies :restart, resources(:service => 'dnsmasq'), :immediately
+  notifies :restart, "service[dnsmasq]"
 end


### PR DESCRIPTION
Hi, there

dnsmasq updates dynamically resolv.conf to its 127.0.0.1 address on resolvconf enabled system. So to handle this behavior I've provided the following patch.

PS. resolvconf is the default way of resolv.conf configuration on distros >= 12.04.

Dennis