### PR TITLE
Move hosts_file cookbook out of integration group

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,9 +2,10 @@ site :opscode
 
 metadata
 
+cookbook "hosts_file"
+
 group :integration do
   cookbook "minitest-handler"
   cookbook "apt"
-  cookbook "hosts_file"
   cookbook "dnsmasq_test", :path => "./test/cookbooks/dnsmasq_test"
 end


### PR DESCRIPTION
AFAIS, the hosts_file is a hard dependency (as can be seen in metadata.rb) and therefore should not be in the integration group in the Berksfile.