### PR TITLE
ensure serverspec path includes /sbin so centos-5.11 tests will pass

### DIFF
--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,3 +1,6 @@
 require 'serverspec'
 
 set :backend, :exec
+
+# add /sbin to path for centos-5.11 platform
+set :path, '/sbin:$PATH'


### PR DESCRIPTION
Without this change, the centos-5.11 platform fails verification because `chkconfig` is not in path.