### PR TITLE
manage /etc/dnsmasq.conf to ensure /etc/dnsmasq.d configs are used

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,5 +1,11 @@
 package 'dnsmasq'
 
+file '/etc/dnsmasq.conf' do
+  mode '0644'
+  content 'conf-dir=/etc/dnsmasq.d'
+  notifies :restart, 'service[dnsmasq]', :delayed
+end
+
 include_recipe 'dnsmasq::dns' if node['dnsmasq']['enable_dns']
 include_recipe 'dnsmasq::dhcp' if node['dnsmasq']['enable_dhcp']
 


### PR DESCRIPTION
Resolves #9, fixes centos-6.6 platform tests