### PR TITLE
Fix dnsmasq.conf

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -3,6 +3,20 @@ package 'dnsmasq'
 include_recipe 'dnsmasq::dns' if node['dnsmasq']['enable_dns']
 include_recipe 'dnsmasq::dhcp' if node['dnsmasq']['enable_dhcp']
 
+# Keep defaults for the package installed in the system (normally
+# a fully commented file), but make sure that conf-dir is set
+existingconf = Hash[File.readlines('/etc/dnsmasq.conf').select { |l| /^[^#\n]/.match(l) }.map { |l| l.strip.split '=' }]
+existingconf['conf-dir'] = '/etc/dnsmasq.d'
+
+template '/etc/dnsmasq.conf' do
+  source 'dynamic_config.erb'
+  mode 0644
+  variables(
+    :config => existingconf,
+    :list   => nil
+  )
+end
+
 service 'dnsmasq' do
   action [:enable, :start]
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -5,7 +5,11 @@ include_recipe 'dnsmasq::dhcp' if node['dnsmasq']['enable_dhcp']
 
 # Keep defaults for the package installed in the system (normally
 # a fully commented file), but make sure that conf-dir is set
-existingconf = Hash[File.readlines('/etc/dnsmasq.conf').select { |l| /^[^#\n]/.match(l) }.map { |l| l.strip.split '=' }]
+if File.exists?('/etc/dnsmasq.conf')
+  existingconf = Hash[File.readlines('/etc/dnsmasq.conf').select { |l| /^[^#\n]/.match(l) }.map { |l| l.strip.split '=' }]
+else
+  existingconf = {}
+end
 existingconf['conf-dir'] = '/etc/dnsmasq.d'
 
 template '/etc/dnsmasq.conf' do


### PR DESCRIPTION
On some systems, the dnsmasq.conf file does not set '/etc/dnsmasq.d' as a conf-dir, and the service does not run with the `--conf-dir` parameter set. This leads to a situation where cookbook settings are not applied to dnsmasq when it runs.

This fixes that issue by parsing the existing conf file (if anything is set), and overriding the 'conf-dir' setting to what is used by the dhcp and dns recipes. This behavior ensures that users can still specify settings in that file elsewhere while pulling in the config from this cookbook.