### PR TITLE
Replace hosts_file cookbook dependency with hostsfile cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DNSMasq
 
-Install and configure dnsmasq. Depends on the [hosts_file cookbook](https://github.com/hw-cookbooks/hosts_file).
+Install and configure dnsmasq. Depends on the [hostsfile cookbook](https://github.com/customink-webops/hostsfile).
 
 # Recipes
 
@@ -34,7 +34,7 @@ Includes the `default` and `manage_hostsfile` recipes, then writes the content o
 
 ## manage_hostsfile
 
-Loads the `dnsmasq` data bag `managed_hosts` item and merges it with any nodes in the `[:dnsmasq][:managed_hosts]` attribute, then writes them out the the `/etc/hosts/` via the `hosts_file` cookbook.
+Loads the `dnsmasq` data bag `managed_hosts` item and merges it with any nodes in the `[:dnsmasq][:managed_hosts]` attribute, then writes them out the the `/etc/hosts/` via the `hostsfile` cookbook.
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,10 @@ If you need manage your DNS hosts you may use the `dnsmasq` data bag `managed_ho
 ```json
 {
     "id": "managed_hosts",
-    "192.168.0.100": "www.google.com",
-    "192.168.0.101": ["www.yahoo.com", "www.altavista.com"]
+    "maps": {
+      "192.168.0.100": "www.google.com",
+      "192.168.0.101": ["www.yahoo.com", "www.altavista.com"]
+    }
 }
 ```
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'Apache 2.0'
 description 'Installs and configures dnsmasq'
 version '0.2.0'
 
-depends 'hosts_file'
+depends 'hostsfile'
 
 %w(ubuntu debian redhat centos scientific oracle).each do |os|
   supports os

--- a/recipes/manage_hostsfile.rb
+++ b/recipes/manage_hostsfile.rb
@@ -9,11 +9,11 @@ managed_hosts.merge!(managed_hosts_bag['maps']) if managed_hosts_bag
 managed_hosts.merge!(node['dnsmasq']['managed_hosts'].to_hash) if node['dnsmasq']['managed_hosts']
 
 managed_hosts.each do |ip, host|
-  host = host.is_a?(Array) ? host.map { |i| i } : host.split(' ')
-  hosts_file_entry ip do
-    hostname host.shift
-    aliases host unless host.empty?
-    comment 'dnsmasq managed entry'
-    notifies :restart, 'service[dnsmasq]'
+  host = host.is_a?(Array) ? host.join(' ') : host
+  hostsfile_entry ip do
+    hostname host
+    unique   false
+    notifies :restart, 'service[dnsmasq]', :delayed
+    action   :create
   end
 end


### PR DESCRIPTION
While testing this cookbook and the managed_hosts recipe I saw that the resources were created and apparently run as part of the chef converge, however they never actually updated my hosts file! I have replaced the `hosts_file` cookbook dependency with the `hostsfile` cookbook which has never failed me in the past. 

Hopefully you don't find this to be an offensive PR as I know you guys wrote the `hosts_file` cookbook.
